### PR TITLE
Downgrade to Go 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/maragudk/goqite
 
-go 1.21
+go 1.18
 
 require github.com/mattn/go-sqlite3 v1.14.19
 


### PR DESCRIPTION
Because we don't need anything newer.