### PR TITLE
Fix flaky tests

### DIFF
--- a/goqite_test.go
+++ b/goqite_test.go
@@ -107,7 +107,7 @@ func TestQueue_Receive(t *testing.T) {
 
 		m := &goqite.Message{
 			Body:  []byte("yo"),
-			Delay: time.Millisecond,
+			Delay: 2 * time.Millisecond,
 		}
 
 		err := q.Send(context.Background(), *m)
@@ -117,7 +117,7 @@ func TestQueue_Receive(t *testing.T) {
 		is.NotError(t, err)
 		is.Nil(t, m)
 
-		time.Sleep(time.Millisecond)
+		time.Sleep(2 * time.Millisecond)
 
 		m, err = q.Receive(context.Background())
 		is.NotError(t, err)


### PR DESCRIPTION
Some of the tests depend on timing (because I'm not mocking the time), and need some more headroom, especially on slower machines.

Fixes #19