### PR TITLE
Add job runner timeout option

### DIFF
--- a/jobs/runner_test.go
+++ b/jobs/runner_test.go
@@ -221,6 +221,6 @@ func newRunner(t *testing.T) (*goqite.Queue, *jobs.Runner) {
 	t.Helper()
 
 	q := internaltesting.NewQ(t, goqite.NewOpts{Timeout: 100 * time.Millisecond}, ":memory:")
-	r := jobs.NewRunner(jobs.NewRunnerOpts{Limit: 10, Log: internaltesting.NewLogger(t), Queue: q, ExtendTimeout: 100 * time.Millisecond})
+	r := jobs.NewRunner(jobs.NewRunnerOpts{Limit: 10, Log: internaltesting.NewLogger(t), Queue: q, Extend: 100 * time.Millisecond})
 	return q, r
 }


### PR DESCRIPTION
Otherwise, the underlying queue could have a much smaller timeout, and the runner wouldn't work properly.

Also:
- Remove the `done` channel, we can just use `jobCtx` directly.
- Some more doc comments.
- Add logging before job run.
- Add a test for the extension.