### PR TITLE
Add error logging support

### DIFF
--- a/internal/testing/testing.go
+++ b/internal/testing/testing.go
@@ -71,6 +71,10 @@ func (f Logger) Info(msg string, args ...any) {
 	f(msg, args...)
 }
 
+func (f Logger) Error(msg string, args ...any) {
+	f(msg, args...)
+}
+
 func NewLogger(t *testing.T) Logger {
 	t.Helper()
 


### PR DESCRIPTION
Hey - nice library, thanks for creating it! I maintain [pagoda](https://github.com/mikestefanello/pagoda), a full-stack, web dev starter kit, and am considering bringing in goqite. It currently defaults to Postgres for storage and Redis for caching and task queues, but I'm working on potentially switching that out for SQLite which is how I came across this project.

This is a simple change to support logging errors as _errors_ rather than _info_, which I thought was useful. I have a few other small ideas/tweaks, but I'll open separate PR/issues for.