### PR TITLE
Add a message priority

### DIFF
--- a/goqite.go
+++ b/goqite.go
@@ -86,9 +86,9 @@ type Queue struct {
 type ID string
 
 type Message struct {
+	ID       ID
 	Body     []byte
 	Delay    time.Duration
-	ID       ID
 	Priority int // Higher priority messages are received first
 }
 

--- a/internal/testing/schema_postgres.sql
+++ b/internal/testing/schema_postgres.sql
@@ -15,11 +15,12 @@ create table goqite (
   queue text not null,
   body bytea not null,
   timeout timestamptz not null default now(),
-  received integer not null default 0
+  received integer not null default 0,
+  priority integer not null default 0
 );
 
 create trigger goqite_updated_timestamp
 before update on goqite
 for each row execute procedure update_timestamp();
 
-create index goqite_queue_created_idx on goqite (queue, created);
+create index goqite_queue_priority_created_idx on goqite (queue, priority desc, created);

--- a/internal/testing/schema_sqlite.sql
+++ b/internal/testing/schema_sqlite.sql
@@ -5,11 +5,12 @@ create table goqite (
   queue text not null,
   body blob not null,
   timeout text not null default (strftime('%Y-%m-%dT%H:%M:%fZ')),
-  received integer not null default 0
+  received integer not null default 0,
+  priority integer not null default 0
 ) strict;
 
 create trigger goqite_updated_timestamp after update on goqite begin
   update goqite set updated = strftime('%Y-%m-%dT%H:%M:%fZ') where id = old.id;
 end;
 
-create index goqite_queue_created_idx on goqite (queue, created);
+create index goqite_queue_priority_created_idx on goqite (queue, priority desc, created);

--- a/jobs/runner.go
+++ b/jobs/runner.go
@@ -209,21 +209,21 @@ func (r *Runner) Register(name string, job Func) {
 }
 
 // Create a message for the named job in the given queue.
-func Create(ctx context.Context, q *goqite.Queue, name string, m goqite.Message) error {
+func Create(ctx context.Context, q *goqite.Queue, name string, m goqite.Message) (goqite.ID, error) {
 	var buf bytes.Buffer
 	if err := gob.NewEncoder(&buf).Encode(message{Name: name, Message: m.Body}); err != nil {
-		return err
+		return "", err
 	}
-	return q.Send(ctx, goqite.Message{Body: buf.Bytes(), Delay: m.Delay, Priority: m.Priority})
+	return q.SendAndGetID(ctx, goqite.Message{Body: buf.Bytes(), Delay: m.Delay, Priority: m.Priority})
 }
 
 // CreateTx is like Create, but within an existing transaction.
-func CreateTx(ctx context.Context, tx *sql.Tx, q *goqite.Queue, name string, m goqite.Message) error {
+func CreateTx(ctx context.Context, tx *sql.Tx, q *goqite.Queue, name string, m goqite.Message) (goqite.ID, error) {
 	var buf bytes.Buffer
 	if err := gob.NewEncoder(&buf).Encode(message{Name: name, Message: m.Body}); err != nil {
-		return err
+		return "", err
 	}
-	return q.SendTx(ctx, tx, goqite.Message{Body: buf.Bytes(), Delay: m.Delay, Priority: m.Priority})
+	return q.SendAndGetIDTx(ctx, tx, goqite.Message{Body: buf.Bytes(), Delay: m.Delay, Priority: m.Priority})
 }
 
 // logger matches the info level method from the slog.Logger.

--- a/jobs/runner.go
+++ b/jobs/runner.go
@@ -209,21 +209,21 @@ func (r *Runner) Register(name string, job Func) {
 }
 
 // Create a message for the named job in the given queue.
-func Create(ctx context.Context, q *goqite.Queue, name string, m []byte) error {
+func Create(ctx context.Context, q *goqite.Queue, name string, m goqite.Message) error {
 	var buf bytes.Buffer
-	if err := gob.NewEncoder(&buf).Encode(message{Name: name, Message: m}); err != nil {
+	if err := gob.NewEncoder(&buf).Encode(message{Name: name, Message: m.Body}); err != nil {
 		return err
 	}
-	return q.Send(ctx, goqite.Message{Body: buf.Bytes()})
+	return q.Send(ctx, goqite.Message{Body: buf.Bytes(), Delay: m.Delay, Priority: m.Priority})
 }
 
 // CreateTx is like Create, but within an existing transaction.
-func CreateTx(ctx context.Context, tx *sql.Tx, q *goqite.Queue, name string, m []byte) error {
+func CreateTx(ctx context.Context, tx *sql.Tx, q *goqite.Queue, name string, m goqite.Message) error {
 	var buf bytes.Buffer
-	if err := gob.NewEncoder(&buf).Encode(message{Name: name, Message: m}); err != nil {
+	if err := gob.NewEncoder(&buf).Encode(message{Name: name, Message: m.Body}); err != nil {
 		return err
 	}
-	return q.SendTx(ctx, tx, goqite.Message{Body: buf.Bytes()})
+	return q.SendTx(ctx, tx, goqite.Message{Body: buf.Bytes(), Delay: m.Delay, Priority: m.Priority})
 }
 
 // logger matches the info level method from the slog.Logger.

--- a/jobs/runner_test.go
+++ b/jobs/runner_test.go
@@ -57,7 +57,7 @@ func TestRunner_Start(t *testing.T) {
 			return nil
 		})
 
-		err := jobs.Create(ctx, q, "test", []byte("yo"))
+		err := jobs.Create(ctx, q, "test", goqite.Message{Body: []byte("yo")})
 		is.NotError(t, err)
 
 		r.Start(ctx)
@@ -79,7 +79,7 @@ func TestRunner_Start(t *testing.T) {
 			return nil
 		})
 
-		err := jobs.Create(ctx, q, "different-test", []byte("yo"))
+		err := jobs.Create(ctx, q, "different-test", goqite.Message{Body: []byte("yo")})
 		is.NotError(t, err)
 
 		r.Start(ctx)
@@ -93,7 +93,7 @@ func TestRunner_Start(t *testing.T) {
 		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 		defer cancel()
 
-		err := jobs.Create(ctx, q, "test", []byte("yo"))
+		err := jobs.Create(ctx, q, "test", goqite.Message{Body: []byte("yo")})
 		is.NotError(t, err)
 
 		defer func() {
@@ -116,7 +116,7 @@ func TestRunner_Start(t *testing.T) {
 			panic("test panic")
 		})
 
-		err := jobs.Create(ctx, q, "test", []byte("yo"))
+		err := jobs.Create(ctx, q, "test", goqite.Message{Body: []byte("yo")})
 		is.NotError(t, err)
 
 		r.Start(ctx)
@@ -135,7 +135,7 @@ func TestRunner_Start(t *testing.T) {
 			return nil
 		})
 
-		err := jobs.Create(ctx, q, "test", []byte("yo"))
+		err := jobs.Create(ctx, q, "test", goqite.Message{Body: []byte("yo")})
 		is.NotError(t, err)
 
 		r.Start(ctx)
@@ -159,7 +159,7 @@ func TestCreateTx(t *testing.T) {
 		})
 
 		err := internalsql.InTx(ctx, db, func(tx *sql.Tx) error {
-			return jobs.CreateTx(ctx, tx, q, "test", []byte("yo"))
+			return jobs.CreateTx(ctx, tx, q, "test", goqite.Message{Body: []byte("yo")})
 		})
 		is.NotError(t, err)
 
@@ -212,7 +212,7 @@ func ExampleRunner_Start() {
 	})
 
 	// Create a "print" job with a message.
-	if err := jobs.Create(context.Background(), q, "print", []byte("Yo")); err != nil {
+	if err := jobs.Create(context.Background(), q, "print", goqite.Message{Body: []byte("Yo")}); err != nil {
 		log.Info("Error creating job", "error", err)
 	}
 

--- a/jobs/runner_test.go
+++ b/jobs/runner_test.go
@@ -57,7 +57,7 @@ func TestRunner_Start(t *testing.T) {
 			return nil
 		})
 
-		err := jobs.Create(ctx, q, "test", goqite.Message{Body: []byte("yo")})
+		_, err := jobs.Create(ctx, q, "test", goqite.Message{Body: []byte("yo")})
 		is.NotError(t, err)
 
 		r.Start(ctx)
@@ -79,7 +79,7 @@ func TestRunner_Start(t *testing.T) {
 			return nil
 		})
 
-		err := jobs.Create(ctx, q, "different-test", goqite.Message{Body: []byte("yo")})
+		_, err := jobs.Create(ctx, q, "different-test", goqite.Message{Body: []byte("yo")})
 		is.NotError(t, err)
 
 		r.Start(ctx)
@@ -93,7 +93,7 @@ func TestRunner_Start(t *testing.T) {
 		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 		defer cancel()
 
-		err := jobs.Create(ctx, q, "test", goqite.Message{Body: []byte("yo")})
+		_, err := jobs.Create(ctx, q, "test", goqite.Message{Body: []byte("yo")})
 		is.NotError(t, err)
 
 		defer func() {
@@ -116,7 +116,7 @@ func TestRunner_Start(t *testing.T) {
 			panic("test panic")
 		})
 
-		err := jobs.Create(ctx, q, "test", goqite.Message{Body: []byte("yo")})
+		_, err := jobs.Create(ctx, q, "test", goqite.Message{Body: []byte("yo")})
 		is.NotError(t, err)
 
 		r.Start(ctx)
@@ -135,7 +135,7 @@ func TestRunner_Start(t *testing.T) {
 			return nil
 		})
 
-		err := jobs.Create(ctx, q, "test", goqite.Message{Body: []byte("yo")})
+		_, err := jobs.Create(ctx, q, "test", goqite.Message{Body: []byte("yo")})
 		is.NotError(t, err)
 
 		r.Start(ctx)
@@ -156,11 +156,11 @@ func TestRunner_Start(t *testing.T) {
 		})
 
 		// Create jobs with different priorities
-		err := jobs.Create(ctx, q, "test", goqite.Message{Body: []byte("low"), Priority: 0})
+		_, err := jobs.Create(ctx, q, "test", goqite.Message{Body: []byte("low"), Priority: 0})
 		is.NotError(t, err)
-		err = jobs.Create(ctx, q, "test", goqite.Message{Body: []byte("high"), Priority: 10})
+		_, err = jobs.Create(ctx, q, "test", goqite.Message{Body: []byte("high"), Priority: 10})
 		is.NotError(t, err)
-		err = jobs.Create(ctx, q, "test", goqite.Message{Body: []byte("medium"), Priority: 5})
+		_, err = jobs.Create(ctx, q, "test", goqite.Message{Body: []byte("medium"), Priority: 5})
 		is.NotError(t, err)
 
 		r.Start(ctx)
@@ -189,7 +189,8 @@ func TestCreateTx(t *testing.T) {
 		})
 
 		err := internalsql.InTx(ctx, db, func(tx *sql.Tx) error {
-			return jobs.CreateTx(ctx, tx, q, "test", goqite.Message{Body: []byte("yo")})
+			_, err := jobs.CreateTx(ctx, tx, q, "test", goqite.Message{Body: []byte("yo")})
+			return err
 		})
 		is.NotError(t, err)
 
@@ -242,7 +243,7 @@ func ExampleRunner_Start() {
 	})
 
 	// Create a "print" job with a message.
-	if err := jobs.Create(context.Background(), q, "print", goqite.Message{Body: []byte("Yo")}); err != nil {
+	if _, err := jobs.Create(context.Background(), q, "print", goqite.Message{Body: []byte("Yo")}); err != nil {
 		log.Info("Error creating job", "error", err)
 	}
 

--- a/jobs/schema_sqlite.sql
+++ b/jobs/schema_sqlite.sql
@@ -5,11 +5,12 @@ create table goqite (
   queue text not null,
   body blob not null,
   timeout text not null default (strftime('%Y-%m-%dT%H:%M:%fZ')),
-  received integer not null default 0
+  received integer not null default 0,
+  priority integer not null default 0
 ) strict;
 
 create trigger goqite_updated_timestamp after update on goqite begin
   update goqite set updated = strftime('%Y-%m-%dT%H:%M:%fZ') where id = old.id;
 end;
 
-create index goqite_queue_created_idx on goqite (queue, created);
+create index goqite_queue_priority_created_idx on goqite (queue, priority desc, created);

--- a/schema_postgres.sql
+++ b/schema_postgres.sql
@@ -15,11 +15,12 @@ create table goqite (
   queue text not null,
   body bytea not null,
   timeout timestamptz not null default now(),
-  received integer not null default 0
+  received integer not null default 0,
+  priority integer not null default 0
 );
 
 create trigger goqite_updated_timestamp
 before update on goqite
 for each row execute procedure update_timestamp();
 
-create index goqite_queue_created_idx on goqite (queue, created);
+create index goqite_queue_priority_created_idx on goqite (queue, priority desc, created);

--- a/schema_sqlite.sql
+++ b/schema_sqlite.sql
@@ -5,11 +5,12 @@ create table goqite (
   queue text not null,
   body blob not null,
   timeout text not null default (strftime('%Y-%m-%dT%H:%M:%fZ')),
-  received integer not null default 0
+  received integer not null default 0,
+  priority integer not null default 0
 ) strict;
 
 create trigger goqite_updated_timestamp after update on goqite begin
   update goqite set updated = strftime('%Y-%m-%dT%H:%M:%fZ') where id = old.id;
 end;
 
-create index goqite_queue_created_idx on goqite (queue, created);
+create index goqite_queue_priority_created_idx on goqite (queue, priority desc, created);


### PR DESCRIPTION
This adds a priority field to the `goqite.Message`. Messages with higher priority are received first.

This also changes the function signature for creating jobs, which now takes a whole message, instead of just the message body. This enables creating delayed jobs and jobs with different priorities.

Fixes #62