### PR TITLE
Receive and then wait for pollinterval

### DIFF
--- a/goqite.go
+++ b/goqite.go
@@ -217,6 +217,15 @@ func (q *Queue) ReceiveTx(ctx context.Context, tx *sql.Tx) (*Message, error) {
 // ReceiveAndWait for a Message from the queue, polling at the given interval, until the context is cancelled.
 // If the context is cancelled, the error will be non-nil. See [context.Context.Err].
 func (q *Queue) ReceiveAndWait(ctx context.Context, interval time.Duration) (*Message, error) {
+
+	m, err := q.Receive(context.WithoutCancel(ctx))
+	if err != nil {
+		return nil, err
+	}
+	if m != nil {
+		return m, nil
+	}
+
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 


### PR DESCRIPTION
Currently ReceiveAndWait first starts a ticker, and then on a tick, calls q.Receive.

As a side effect, while using the jobs/Runner, there is a mandatory delay of pollinterval even if there are more jobs that can be immediately picked up.

This patch, calls q.Receive before waiting on ticker, if nothing is returned, continues with setting up the ticker and calling q.Receive in a loop.