### PR TITLE
Close extend before proceeding with Delete.

### DIFF
--- a/goqite.go
+++ b/goqite.go
@@ -188,19 +188,21 @@ func (q *Queue) ReceiveTx(ctx context.Context, tx *sql.Tx) (*Message, error) {
 
 	case SQLFlavorPostgreSQL:
 		query := `
-			update goqite
-			set
-				timeout = $1,
-				received = received + 1
-			where id = (
+			with next as (
 				select id from goqite
 				where
 					queue = $2 and
 					$3 >= timeout and
 					received < $4
 				order by priority desc, created
+				for update skip locked
 				limit 1
 			)
+			update goqite
+			set
+				timeout = $1,
+				received = received + 1
+			where id in (select id from next)
 			returning id, body`
 
 		if err := tx.QueryRowContext(ctx, query, timeout, q.name, now, q.maxReceive).Scan(&m.ID, &m.Body); err != nil {

--- a/goqite.go
+++ b/goqite.go
@@ -83,6 +83,14 @@ type Queue struct {
 	timeout    time.Duration
 }
 
+func (q *Queue) inTx(ctx context.Context, cb func(*sql.Tx) error) error {
+	if q.flavor == SQLFlavorPostgreSQL {
+		return internalsql.InTxWithIsolation(ctx, q.db, sql.LevelReadCommitted, cb)
+	}
+
+	return internalsql.InTx(ctx, q.db, cb)
+}
+
 type ID string
 
 type Message struct {
@@ -94,7 +102,7 @@ type Message struct {
 
 // Send a Message to the queue with an optional delay.
 func (q *Queue) Send(ctx context.Context, m Message) error {
-	return internalsql.InTx(ctx, q.db, func(tx *sql.Tx) error {
+	return q.inTx(ctx, func(tx *sql.Tx) error {
 		return q.SendTx(ctx, tx, m)
 	})
 }
@@ -109,7 +117,7 @@ func (q *Queue) SendTx(ctx context.Context, tx *sql.Tx, m Message) error {
 // to interact with the message without receiving it first.
 func (q *Queue) SendAndGetID(ctx context.Context, m Message) (ID, error) {
 	var id ID
-	err := internalsql.InTx(ctx, q.db, func(tx *sql.Tx) error {
+	err := q.inTx(ctx, func(tx *sql.Tx) error {
 		var err error
 		id, err = q.SendAndGetIDTx(ctx, tx, m)
 		return err
@@ -146,7 +154,7 @@ func (q *Queue) SendAndGetIDTx(ctx context.Context, tx *sql.Tx, m Message) (ID, 
 // Receive a Message from the queue, or nil if there is none.
 func (q *Queue) Receive(ctx context.Context) (*Message, error) {
 	var m *Message
-	err := internalsql.InTx(ctx, q.db, func(tx *sql.Tx) error {
+	err := q.inTx(ctx, func(tx *sql.Tx) error {
 		var err error
 		m, err = q.ReceiveTx(ctx, tx)
 		return err
@@ -248,7 +256,7 @@ func (q *Queue) ReceiveAndWait(ctx context.Context, interval time.Duration) (*Me
 
 // Extend a Message timeout by the given delay from now.
 func (q *Queue) Extend(ctx context.Context, id ID, delay time.Duration) error {
-	return internalsql.InTx(ctx, q.db, func(tx *sql.Tx) error {
+	return q.inTx(ctx, func(tx *sql.Tx) error {
 		return q.ExtendTx(ctx, tx, id, delay)
 	})
 }
@@ -275,7 +283,7 @@ func (q *Queue) ExtendTx(ctx context.Context, tx *sql.Tx, id ID, delay time.Dura
 
 // Delete a Message from the queue by id.
 func (q *Queue) Delete(ctx context.Context, id ID) error {
-	return internalsql.InTx(ctx, q.db, func(tx *sql.Tx) error {
+	return q.inTx(ctx, func(tx *sql.Tx) error {
 		return q.DeleteTx(ctx, tx, id)
 	})
 }

--- a/internal/sql/tx.go
+++ b/internal/sql/tx.go
@@ -16,8 +16,12 @@ const maxRetries = 3
 const retryBackoff = 10 * time.Millisecond
 
 func InTx(ctx context.Context, db *sql.DB, cb func(*sql.Tx) error) (err error) {
+	return InTxWithIsolation(ctx, db, sql.LevelSerializable, cb)
+}
+
+func InTxWithIsolation(ctx context.Context, db *sql.DB, isolation sql.IsolationLevel, cb func(*sql.Tx) error) (err error) {
 	for i := range maxRetries {
-		err = inTx(ctx, db, cb)
+		err = inTx(ctx, db, isolation, cb)
 		if !isSerializationError(err) {
 			return err
 		}
@@ -40,8 +44,8 @@ func InTx(ctx context.Context, db *sql.DB, cb func(*sql.Tx) error) (err error) {
 	return err
 }
 
-func inTx(ctx context.Context, db *sql.DB, cb func(*sql.Tx) error) (err error) {
-	tx, txErr := db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+func inTx(ctx context.Context, db *sql.DB, isolation sql.IsolationLevel, cb func(*sql.Tx) error) (err error) {
+	tx, txErr := db.BeginTx(ctx, &sql.TxOptions{Isolation: isolation})
 	if txErr != nil {
 		return fmt.Errorf("cannot start tx: %w", txErr)
 	}

--- a/internal/sql/tx.go
+++ b/internal/sql/tx.go
@@ -3,10 +3,44 @@ package sql
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
+	"math/rand/v2"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
+const maxRetries = 3
+
+const retryBackoff = 10 * time.Millisecond
+
 func InTx(ctx context.Context, db *sql.DB, cb func(*sql.Tx) error) (err error) {
+	for i := range maxRetries {
+		err = inTx(ctx, db, cb)
+		if !isSerializationError(err) {
+			return err
+		}
+
+		if i == maxRetries-1 {
+			return err
+		}
+
+		backoff := retryBackoff * time.Duration(1<<i)
+		jitter := time.Duration(rand.Int64N(int64(backoff)))
+		timer := time.NewTimer(backoff + jitter)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+
+	return err
+}
+
+func inTx(ctx context.Context, db *sql.DB, cb func(*sql.Tx) error) (err error) {
 	tx, txErr := db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
 	if txErr != nil {
 		return fmt.Errorf("cannot start tx: %w", txErr)
@@ -35,4 +69,9 @@ func rollback(tx *sql.Tx, err error) error {
 		return fmt.Errorf("cannot roll back tx after error (tx error: %v), original error: %w", txErr, err)
 	}
 	return err
+}
+
+func isSerializationError(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "40001"
 }

--- a/internal/sql/tx_test.go
+++ b/internal/sql/tx_test.go
@@ -1,0 +1,26 @@
+package sql
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"maragu.dev/is"
+)
+
+func TestIsSerializationError(t *testing.T) {
+	t.Run("matches postgres serialization errors", func(t *testing.T) {
+		err := &pgconn.PgError{Code: "40001"}
+		is.True(t, isSerializationError(err))
+	})
+
+	t.Run("matches wrapped postgres serialization errors", func(t *testing.T) {
+		err := fmt.Errorf("wrapped: %w", &pgconn.PgError{Code: "40001"})
+		is.True(t, isSerializationError(err))
+	})
+
+	t.Run("does not match other errors", func(t *testing.T) {
+		err := &pgconn.PgError{Code: "23505"}
+		is.True(t, !isSerializationError(err))
+	})
+}

--- a/repro_40001_test.go
+++ b/repro_40001_test.go
@@ -1,0 +1,131 @@
+package goqite_test
+
+import (
+	"context"
+	"database/sql"
+	_ "embed"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"maragu.dev/goqite"
+)
+
+//go:embed schema_postgres.sql
+var localReproPostgresSchema string
+
+func TestLocalPostgreSQLBenchmarkStyleCanPrint40001(t *testing.T) {
+	if os.Getenv("GOQITE_TEST_REPRODUCE_40001") == "" {
+		t.Skip("set GOQITE_TEST_REPRODUCE_40001=1 and GOQITE_TEST_POSTGRES_DSN=postgres://user:pass@host:5432/dbname")
+	}
+
+	dsn := os.Getenv("GOQITE_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("set GOQITE_TEST_POSTGRES_DSN=postgres://user:pass@host:5432/dbname")
+	}
+
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	if err := db.PingContext(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	db.SetMaxOpenConns(100)
+	db.SetMaxIdleConns(100)
+
+	if _, err := db.ExecContext(t.Context(), localReproPostgresSchema); err != nil {
+		var pgErr *pgconn.PgError
+		if !errors.As(err, &pgErr) || (pgErr.Code != "42P07" && pgErr.Code != "42710" && pgErr.Code != "42723") {
+			t.Fatal(err)
+		}
+	}
+
+	name := fmt.Sprintf("repro_40001_%d", time.Now().UnixNano())
+	t.Cleanup(func() {
+		if _, err := db.ExecContext(context.WithoutCancel(t.Context()), `delete from goqite where queue = $1`, name); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	q := goqite.New(goqite.NewOpts{
+		DB:         db,
+		MaxReceive: 1000,
+		Name:       name,
+		SQLFlavor:  goqite.SQLFlavorPostgreSQL,
+		Timeout:    time.Second,
+	})
+
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
+	defer cancel()
+
+	const workers = 50
+
+	var seen atomic.Bool
+	var wg sync.WaitGroup
+
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			for ctx.Err() == nil {
+				if err := q.Send(ctx, goqite.Message{Body: []byte("yo")}); err != nil {
+					if isSerializationError(err) {
+						t.Log("send:", err)
+						seen.Store(true)
+						continue
+					}
+					continue
+				}
+
+				m, err := q.Receive(ctx)
+				if err != nil {
+					if isSerializationError(err) {
+						t.Log("receive:", err)
+						seen.Store(true)
+						continue
+					}
+					continue
+				}
+
+				if m == nil {
+					continue
+				}
+
+				err = q.Delete(ctx, m.ID)
+				if err != nil {
+					if isSerializationError(err) {
+						t.Log("delete:", err)
+						seen.Store(true)
+						continue
+					}
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	if seen.Load() {
+		t.Fatal("reproduced 40001; expected this run to succeed without serialization errors")
+	}
+}
+
+func isSerializationError(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "40001"
+}


### PR DESCRIPTION
Lots of serialization errors were popping up in postgres.

This was happening as delete and extend were both running simultaneously sometimes.

This commit forces serialization, extend exits before delete is called

Edit: The above description is from an earlier implementation and is no longer the case.

The real change in the PR is as follows:
- Use Read Committed Isolation for Postgres
- Use `update skip locked` in `receive` query.
- If there is 40001 error, retry.